### PR TITLE
Fail on DNS limit, add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 spf
+gospf
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: go
 go:
   - 1.3
   - 1.4
+  - 1.5
+  - 1.6
 
 install:
   - go get github.com/smartystreets/goconvey/convey

--- a/dns/dns.go
+++ b/dns/dns.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"errors"
-	_ "fmt"
 	"net"
 )
 

--- a/gospf/main.go
+++ b/gospf/main.go
@@ -20,7 +20,7 @@ func main() {
 
 	domain := os.Args[1]
 
-	spf, err := gospf.NewSPF(domain, &dns.GoSPFDNS{}, 0, 0)
+	spf, err := gospf.New(domain, &dns.GoSPFDNS{})
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/gospf/main.go
+++ b/gospf/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/gopistolet/gospf/dns"
 	"github.com/gopistolet/gospf"
+	"github.com/gopistolet/gospf/dns"
 	_ "net"
 	"os"
 )
@@ -20,7 +20,7 @@ func main() {
 
 	domain := os.Args[1]
 
-	spf, err := gospf.NewSPF(domain, &dns.GoSPFDNS{})
+	spf, err := gospf.NewSPF(domain, &dns.GoSPFDNS{}, 0, 0)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/parser_test.go
+++ b/parser_test.go
@@ -214,3 +214,13 @@ func TestModifiers(t *testing.T) {
 	})
 
 }
+
+// Tests functions that don't actually need test coverage so they
+// are not counted against the coverage percentage by `go test -cover`
+//
+// Directive.String
+func TestParserCoverage(t *testing.T) {
+	// Directive.String
+	d := Directive{}
+	_ = d.String()
+}

--- a/spf.go
+++ b/spf.go
@@ -42,10 +42,14 @@ func (spf SPF) String() string {
 	return spf.toString("")
 }
 
-// NewSPF creates a new SPF instance
+// New create a new SPF instance
 // fully loaded with all the SPF directives
 // (so no more DNS lookups must be done after constructing the instance)
-func NewSPF(domain string, dnsResolver dns.DnsResolver, dnsLookupCount int, voidLookupCount int) (*SPF, error) {
+func New(domain string, dnsResolver dns.DnsResolver) (*SPF, error) {
+	return newSPF(domain, dnsResolver, 0, 0)
+}
+
+func newSPF(domain string, dnsResolver dns.DnsResolver, dnsLookupCount int, voidLookupCount int) (*SPF, error) {
 	spf := SPF{
 		Pass:            make([]net.IPNet, 0),
 		Neutral:         make([]net.IPNet, 0),
@@ -157,7 +161,7 @@ func (spf *SPF) handleDirectives() error {
 				if err != nil {
 					return err
 				}
-				include_spf, err := NewSPF(
+				include_spf, err := newSPF(
 					directive.Arguments["domain"], spf.dns, spf.dnsLookupCount, spf.voidLookupCount)
 				if err != nil {
 					return err
@@ -373,7 +377,7 @@ func (spf *SPF) handleModifiers() error {
 				if modifier.Value == "" {
 					return errors.New("No domain given for redirect modifier")
 				}
-				redirect_spf, err := NewSPF(modifier.Value, spf.dns, spf.dnsLookupCount, spf.voidLookupCount)
+				redirect_spf, err := newSPF(modifier.Value, spf.dns, spf.dnsLookupCount, spf.voidLookupCount)
 				if err != nil {
 					return err
 				}

--- a/spf.go
+++ b/spf.go
@@ -468,11 +468,15 @@ func (s *SPF) incVoidLookupCount(amt int) error {
 // PermError means the domain's published records could not be correctly interpreted.
 // These are described in RFC 7208 Section 8.7.
 type PermError struct {
-	s string
+	Message string
 }
 
 func (l *PermError) Error() string {
-	return l.s
+	return "PermError"
+}
+
+func (l *PermError) String() string {
+	return l.Message
 }
 
 // GetRanges composes the CIDR IP ranges following RFC 4632 and RFC 4291


### PR DESCRIPTION
- Adds support for DNS lookup limits (to prevent infinite or excessive recursive lookups)
- Add test coverage for spf.go
