### PR TITLE
Don't return Permerror on no host or empty TXT record

### DIFF
--- a/spf.go
+++ b/spf.go
@@ -64,6 +64,10 @@ func newSPF(domain string, dnsResolver dns.DnsResolver, dnsLookupCount int, void
 	}
 	record, err := spf.dns.GetSPFRecord(domain)
 	if err != nil {
+		// Host does not exist or has no TXT record.
+		if strings.Contains(err.Error(), "no such host") {
+			return &spf, nil
+		}
 		return nil, &PermError{err.Error()}
 	}
 	directives, modifiers, err := getTerms(record)


### PR DESCRIPTION
Fix for #3. But don't know if it's a good way to solve it...
The problem is that net.LookupTXT does not return a specific error if there was no TXT record. It just returns "no such host".
